### PR TITLE
[CHECKOUT-93] Add callCenterOperator userType validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Validate if `userType` is `callCenterOperator`.
+
 ## [0.1.2] - 2021-10-25
 
 ### Fixed 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -94,7 +94,8 @@ class checkEmailAuthConflict {
 
 	init() {
 		const _this = this;
-		$(window).one('orderFormUpdated.vtex', function(evt, orderForm) {
+		$(window).one('orderFormUpdated.vtex', function(_, orderForm) {
+			if (orderForm.userType === 'callCenterOperator') return
 			_this.orderForm = orderForm;
 			_this.lang = vtex ? vtex.i18n.locale : "en";
 			try {
@@ -107,6 +108,7 @@ class checkEmailAuthConflict {
 
 		$(window).on('authenticatedUser.vtexid closed.vtexid', function() {
 			_this.orderForm = vtexjs.checkout.orderForm;
+			if (_this.orderForm.userType === 'callCenterOperator') return
 			try {
 				_this.validate();
 			} catch(e) {


### PR DESCRIPTION
Add callCenterOperator userType validation

[email-checkout-conflict](https://github.com/vtex-apps/email-checkout-conflict) with the validation is linked in:
[Workspace with validation](https://arturodev--alssports.myvtex.com/)